### PR TITLE
CMakeがCRYのソースコードを引っ張ってくるようにした

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -33,14 +33,25 @@ include(${ROOT_USE_FILE})
   include(${Geant4_USE_FILE})
   include_directories(${PROJECT_SOURCE_DIR}/include)
 
+  # CRY
+  include(FetchContent)
+  FetchContent_Declare(
+      cry
+      URL http://nuclear.llnl.gov/simulation/cry_v1.7.tar.gz
+      URL_MD5 85f240bebe81fe0b257e92ef1d390a83
+  )
+  FetchContent_MakeAvailable(cry)
+  file(GLOB cry_headers ${cry_SOURCE_DIR}/src/*.h)
+  file(GLOB cry_sources ${cry_SOURCE_DIR}/src/*.cc)
+  include_directories(${cry_SOURCE_DIR}/src/)
+
 # Locate sources and headers for this project
   file(GLOB sources ${PROJECT_SOURCE_DIR}/src/*.cc)
   file(GLOB headers ${PROJECT_SOURCE_DIR}/include/*.hh)
 
 # Compile and link your application
   add_definitions(${ROOT_CXX_FLAGS})
-  add_executable(${NAME_MAIN_PROGRAM} ${NAME_MAIN_PROGRAM}.cc
-                                      ${sources} ${headers})
+  add_executable(${NAME_MAIN_PROGRAM} ${NAME_MAIN_PROGRAM}.cc ${sources} ${headers} ${cry_sources} ${cry_headers})
   target_link_libraries(${NAME_MAIN_PROGRAM} ${Geant4_LIBRARIES} ROOT::MathCore ROOT::Hist ROOT::Tree)
 
 # Install the executable

--- a/source/include/PrimaryGenerator.hh
+++ b/source/include/PrimaryGenerator.hh
@@ -13,5 +13,8 @@ class PrimaryGenerator : public G4VUserPrimaryGeneratorAction
 
   public:
     void GeneratePrimaries(G4Event*);
+  
+  public: 
+    void GenerateCosmicRay();
 };
 #endif

--- a/source/src/PrimaryGenerator.cc
+++ b/source/src/PrimaryGenerator.cc
@@ -4,9 +4,16 @@
 #include "G4SystemOfUnits.hh"
 #include "G4Event.hh"
 
+#include "CRYSetup.h"
+
 PrimaryGenerator::PrimaryGenerator(){}
 
 PrimaryGenerator::~PrimaryGenerator(){}
+
+void PrimaryGenerator::GenerateCosmicRay(){
+  CRYSetup* fsasetup = new CRYSetup("", "../build/_deps/cry-src/data");
+  // write down CRY code
+}
 
 void PrimaryGenerator::GeneratePrimaries(G4Event* anEvent)
 {


### PR DESCRIPTION
- cmakeしたときにCRYのソースをダウンロードするようにした
- #include "CRYSetup" とかでCRYのクラスとかが使えるようになった